### PR TITLE
:sparkles: Implement strchr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,5 @@ fclean:	clean
 re:	fclean all
 
 tests_run: all
-		gcc -o $(TEST_NAME) $(TEST_SRC) -lcriterion
+		gcc -o $(TEST_NAME) $(TEST_SRC) -lcriterion --coverage
 		./$(TEST_NAME)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ NAME	= libasm.so
 TEST_NAME = unit_tests
 
 ## Sources
-SRC	= src/strlen.asm		\
+SRC	=	src/strlen.asm		\
+		src/strchr.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -23,8 +24,10 @@ ASMFLAGS	= -f elf64
 
 
 ## Tests
-TEST_SRC	=	tests/tests_strlen.c	\
-				tests/my_strlen.c		\
+TEST_SRC	=	tests/my_strlen.c		\
+				tests/tests_strlen.c	\
+				tests/my_strchr.c		\
+				tests/tests_strchr.c	\
 
 .PHONY:	all clean fclean re
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(NAME):	$(OBJ)
 		ld -shared -o $(NAME) $(OBJ)
 
 %.o:	%.asm
-		$(ASM) $(ASMFLAGS) $(SRC)
+		$(ASM) $(ASMFLAGS) $< -o $@
 
 clean:
 		rm -f $(OBJ)

--- a/src/strchr.asm
+++ b/src/strchr.asm
@@ -1,0 +1,24 @@
+BITS 64                 ; 64-bit mode
+SECTION .text           ; Code section
+GLOBAL strchr        ; export "strchr"
+
+strchr:
+        ENTER 0,0           ; starts the program
+
+        .loop:              ; loop to find the c character
+                CMP BYTE [RDI], 0       ; Checks if it's the end of the string
+                JE .not_found           ; True -> jump to the end
+                CMP BYTE [RDI], SIL     ; Checks if the caracters of s is c
+                JE .end                 ; True -> jump to the end
+                INC RDI                 ; Increments the pointer
+                JMP .loop               ; Jumps to itself
+
+        .end:                ; End of the program
+                MOV RAX, RDI            ; Moves the pointer found to RAX
+                LEAVE                   ; Ends the program
+                RET                     ; Returns
+
+        .not_found:          ; Not found
+                MOV RAX, 0              ; Moves 0 to RAX
+                LEAVE                   ; Ends the program
+                RET                     ; Returns

--- a/src/strlen.asm
+++ b/src/strlen.asm
@@ -1,6 +1,6 @@
 BITS 64                 ; 64-bit mode
 SECTION .text           ; Code section
-GLOBAL strlen        ; export "_start"
+GLOBAL strlen        ; export "strlen"
 
 strlen:              ; Loops through the string to return its len
         ENTER 0, 0              ; Starts the program

--- a/tests/functions.h
+++ b/tests/functions.h
@@ -8,3 +8,6 @@
 #pragma once
 
 int my_strlen(char *str);
+char *my_strchr(const char *s, int c);
+
+void redirect_all_std(void);

--- a/tests/my_strchr.c
+++ b/tests/my_strchr.c
@@ -1,0 +1,31 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** my_strchr
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+char *my_strchr(const char *s, int c)
+{
+    void *handle;
+    char *(*function)(const char *, int);
+    char *error;
+    char *result;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return NULL;
+    };
+    function = dlsym(handle, "strchr");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return NULL;
+    }
+    result = function(s, c);
+    dlclose(handle);
+    return result;
+}

--- a/tests/tests_strchr.c
+++ b/tests/tests_strchr.c
@@ -1,0 +1,58 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_strchr
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include "functions.h"
+
+Test(strchr, simple_sentence, .init = redirect_all_std)
+{
+    char *test = "Hello, World!";
+    char *my_result;
+    char *result;
+
+    my_result = my_strchr(test, 'W');
+    result = strchr(test, 'W');
+    cr_assert_eq(my_result, result);
+}
+
+Test(strchr, long_sentence, .init = redirect_all_std)
+{
+    char *test = "lorem ipsum dolor sit amet, consectetur adipiscing elit.\
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\
+    ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit\
+    in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur\
+    sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt\
+    mollit anim id est laborum.";
+    char *my_result;
+    char *result;
+
+    my_result = my_strchr(test, 'a');
+    result = strchr(test, 'a');
+    cr_assert_eq(my_result, result);
+}
+
+Test(strchr, not_found, .init = redirect_all_std)
+{
+    char *test = "Hello, World!";
+    char *my_result;
+    char *result;
+
+    my_result = my_strchr(test, 'z');
+    cr_assert_eq(my_result, NULL);
+}
+
+Test(strchr, empty_string, .init = redirect_all_std)
+{
+    char *test = "";
+    char *my_result;
+    char *result;
+
+    my_result = my_strchr(test, 'z');
+    cr_assert_eq(my_result, NULL);
+}


### PR DESCRIPTION
The `strchr` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asm
BITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL strchr        ; export "strchr"

strchr:
        ENTER 0,0           ; starts the program

        .loop:              ; loop to find the c character
                CMP BYTE [RDI], 0       ; Checks if it's the end of the string
                JE .not_found           ; True -> jump to the end
                CMP BYTE [RDI], SIL     ; Checks if the caracters of s is c
                JE .end                 ; True -> jump to the end
                INC RDI                 ; Increments the pointer
                JMP .loop               ; Jumps to itself

        .end:                ; End of the program
                MOV RAX, RDI            ; Moves the pointer found to RAX
                LEAVE                   ; Ends the program
                RET                     ; Returns

        .not_found:          ; Not found
                MOV RAX, 0              ; Moves 0 to RAX
                LEAVE                   ; Ends the program
                RET                     ; Returns
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/6fb6aa6a-17f7-4b04-947b-ce2875dbfe4d)