### PR TITLE
:sparkles: Implement strrchr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TEST_NAME = unit_tests
 ## Sources
 SRC	=	src/strlen.asm		\
 		src/strchr.asm		\
+		src/strrchr.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -28,6 +29,8 @@ TEST_SRC	=	tests/my_strlen.c		\
 				tests/tests_strlen.c	\
 				tests/my_strchr.c		\
 				tests/tests_strchr.c	\
+				tests/my_strrchr.c		\
+				tests/tests_strrchr.c	\
 
 .PHONY:	all clean fclean re
 

--- a/src/strrchr.asm
+++ b/src/strrchr.asm
@@ -1,0 +1,44 @@
+BITS 64                 ; 64-bit mode
+SECTION .text           ; Code section
+GLOBAL strrchr        ; export "strrchr"
+
+strrchr:
+        ENTER 0,0       ; starts the program
+        CALL strlen     ; Calls the strlen function to get the length of the string
+        MOV RCX, RAX    ; Moves the length to RCX
+
+        .loop:          ; loop to find the last c character
+                CMP RCX, 0      ; Checks if the length is 0
+                JE .not_found        ; If it is 0, then it is the end of the string
+                CMP BYTE [RDI + RCX - 1], SIL  ; Compares the last character with the character
+                JE .found           ; If it is the same, then it is found
+                DEC RCX             ; Decrements the length
+                JMP .loop           ; Jumps to the loop
+
+        .not_found:
+                MOV RAX, 0      ; If the character is not found, return 0
+                LEAVE           ; Ends the program
+                RET
+
+        .found:
+                MOV RAX, RDI    ; If the character is found, return the pointer
+                ADD RAX, RCX    ; Moves the pointer to the last character found
+                DEC RAX     ; Moves the pointer to the last character found
+                LEAVE           ; Ends the program
+                RET
+
+strlen:              ; Loops through the string to return its len
+        ENTER 0, 0              ; Starts the program
+        MOV RCX, 0              ; Initializes the counter
+
+        .loop:                  ; Loop which checks if the character is null or not
+                CMP BYTE [RDI], 0       ; Checks if the character is null
+                JE .end                 ; True -> jumps to the end
+                INC RDI                 ; Increments the pointer
+                INC RCX                 ; False -> increments the length = the result
+                JMP .loop               ; Jumps to the loop
+
+        .end:                   ; End of the program
+                MOV RAX, RCX            ; Moves the length to RAX
+                LEAVE                   ; Ends the program
+                RET                     ; Returns the length of the string

--- a/src/strrchr.asm
+++ b/src/strrchr.asm
@@ -3,42 +3,28 @@ SECTION .text           ; Code section
 GLOBAL strrchr        ; export "strrchr"
 
 strrchr:
-        ENTER 0,0       ; starts the program
-        CALL strlen     ; Calls the strlen function to get the length of the string
-        MOV RCX, RAX    ; Moves the length to RCX
+        ENTER 0, 0       ; starts the program
 
-        .loop:          ; loop to find the last c character
-                CMP RCX, 0      ; Checks if the length is 0
-                JE .not_found        ; If it is 0, then it is the end of the string
-                CMP BYTE [RDI + RCX - 1], SIL  ; Compares the last character with the character
-                JE .found           ; If it is the same, then it is found
-                DEC RCX             ; Decrements the length
-                JMP .loop           ; Jumps to the loop
-
-        .not_found:
-                MOV RAX, 0      ; If the character is not found, return 0
-                LEAVE           ; Ends the program
-                RET
-
-        .found:
-                MOV RAX, RDI    ; If the character is found, return the pointer
-                ADD RAX, RCX    ; Moves the pointer to the last character found
-                DEC RAX     ; Moves the pointer to the last character found
-                LEAVE           ; Ends the program
-                RET
-
-strlen:              ; Loops through the string to return its len
-        ENTER 0, 0              ; Starts the program
-        MOV RCX, 0              ; Initializes the counter
-
-        .loop:                  ; Loop which checks if the character is null or not
-                CMP BYTE [RDI], 0       ; Checks if the character is null
-                JE .end                 ; True -> jumps to the end
+        .start_loop:
+                CMP BYTE [RDI + 1], 0       ; Checks if it's the end of the string
+                JE .loop                ; True -> jump to the loop
                 INC RDI                 ; Increments the pointer
-                INC RCX                 ; False -> increments the length = the result
-                JMP .loop               ; Jumps to the loop
+                JMP .start_loop         ; Jumps to itself
 
-        .end:                   ; End of the program
-                MOV RAX, RCX            ; Moves the length to RAX
+        .loop:              ; loop to find the c character
+                CMP BYTE [RDI], 0       ; Checks if it's the end of the string
+                JE .not_found           ; True -> jump to the end
+                CMP BYTE [RDI], SIL     ; Checks if the caracters of s is c
+                JE .end                 ; True -> jump to the end
+                DEC RDI                 ; Decrements the pointer
+                JMP .loop               ; Jumps to itself
+
+        .end:                ; End of the program
+                MOV RAX, RDI            ; Moves the pointer found to RAX
                 LEAVE                   ; Ends the program
-                RET                     ; Returns the length of the string
+                RET                     ; Returns
+
+        .not_found:          ; Not found
+                MOV RAX, 0              ; Moves 0 to RAX
+                LEAVE                   ; Ends the program
+                RET                     ; Returns

--- a/tests/functions.h
+++ b/tests/functions.h
@@ -9,5 +9,6 @@
 
 int my_strlen(char *str);
 char *my_strchr(const char *s, int c);
+char *my_strrchr(const char *s, int c);
 
 void redirect_all_std(void);

--- a/tests/my_strrchr.c
+++ b/tests/my_strrchr.c
@@ -1,0 +1,31 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** my_strchr
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+char *my_strrchr(const char *s, int c)
+{
+    void *handle;
+    char *(*function)(const char *, int);
+    char *error;
+    char *result;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return NULL;
+    };
+    function = dlsym(handle, "strrchr");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return NULL;
+    }
+    result = function(s, c);
+    dlclose(handle);
+    return result;
+}

--- a/tests/tests_strrchr.c
+++ b/tests/tests_strrchr.c
@@ -1,0 +1,48 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_strrchr
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include "functions.h"
+
+Test(my_strrchr, simple_strrchr, .init = redirect_all_std)
+{
+    char *test = "Hello!";
+    char *my_result;
+    char *result;
+
+    my_result = my_strrchr(test, 'l');
+    result = strrchr(test, 'l');
+    cr_assert_str_eq(my_result, result);
+}
+
+Test(my_strrchr, long_strrchr, .init = redirect_all_std)
+{
+    char *test = "lorem ipsum dolor sit amet, consectetur adipiscing elit.\
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\
+    ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit\
+    in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur\
+    sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt\
+    mollit anim id est laborum.";
+    char *my_result;
+    char *result;
+
+    my_result = my_strrchr(test, 'a');
+    result = strrchr(test, 'a');
+    cr_assert_str_eq(my_result, result);
+}
+
+// Test(my_strrchr, not_found_strrchr, .init = redirect_all_std)
+// {
+//     char *test = "Hello, World!";
+//     char *my_result;
+//     char *result;
+
+//     my_result = my_strrchr(test, 'z');
+//     cr_assert_eq(my_result, NULL);
+// }

--- a/tests/tests_strrchr.c
+++ b/tests/tests_strrchr.c
@@ -37,12 +37,23 @@ Test(my_strrchr, long_strrchr, .init = redirect_all_std)
     cr_assert_str_eq(my_result, result);
 }
 
-// Test(my_strrchr, not_found_strrchr, .init = redirect_all_std)
-// {
-//     char *test = "Hello, World!";
-//     char *my_result;
-//     char *result;
+Test(my_strrchr, not_found_strrchr, .init = redirect_all_std)
+{
+    char *test = "Hello, World!";
+    char *my_result;
+    char *result;
 
-//     my_result = my_strrchr(test, 'z');
-//     cr_assert_eq(my_result, NULL);
-// }
+    my_result = my_strrchr(test, 'z');
+    cr_assert_eq(my_result, NULL);
+}
+
+Test(my_strrchr, empty_strrchr, .init = redirect_all_std)
+{
+    char *test = "";
+    char *my_result;
+    char *result;
+
+    my_result = my_strrchr(test, 'z');
+    result = strrchr(test, 'z');
+    cr_assert_eq(my_result, result);
+}


### PR DESCRIPTION
The `strrchr` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asm
BITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL strrchr        ; export "strrchr"

strrchr:
        ENTER 0, 0       ; starts the program

        .start_loop:
                CMP BYTE [RDI + 1], 0       ; Checks if it's the end of the string
                JE .loop                ; True -> jump to the loop
                INC RDI                 ; Increments the pointer
                JMP .start_loop         ; Jumps to itself

        .loop:              ; loop to find the c character
                CMP BYTE [RDI], 0       ; Checks if it's the end of the string
                JE .not_found           ; True -> jump to the end
                CMP BYTE [RDI], SIL     ; Checks if the caracters of s is c
                JE .end                 ; True -> jump to the end
                DEC RDI                 ; Decrements the pointer
                JMP .loop               ; Jumps to itself

        .end:                ; End of the program
                MOV RAX, RDI            ; Moves the pointer found to RAX
                LEAVE                   ; Ends the program
                RET                     ; Returns

        .not_found:          ; Not found
                MOV RAX, 0              ; Moves 0 to RAX
                LEAVE                   ; Ends the program
                RET                     ; Returns
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/712b1340-85d4-4f39-8813-7c4410a5c26a)
