### PR TITLE
:sparkles: Implement memset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ TEST_NAME = unit_tests
 SRC	=	src/strlen.asm		\
 		src/strchr.asm		\
 		src/strrchr.asm		\
+		src/memset.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -31,6 +32,8 @@ TEST_SRC	=	tests/my_strlen.c		\
 				tests/tests_strchr.c	\
 				tests/my_strrchr.c		\
 				tests/tests_strrchr.c	\
+				tests/my_memset.c			\
+				tests/tests_memset.c	\
 
 .PHONY:	all clean fclean re
 

--- a/src/memset.asm
+++ b/src/memset.asm
@@ -1,0 +1,19 @@
+BITS 64                 ; 64-bit mode
+SECTION .text           ; Code section
+GLOBAL memset        ; export "memset"
+
+memset:
+        ENTER 0, 0       ; starts the program
+        MOV RCX, RDX    ; Move the value of RDX into RCX
+
+        .loop:
+                CMP RCX, 0      ; If RCX is 0, we are done
+                JE .done
+                MOV BYTE [RDI], SIL ; Set the memory at RDI to the value of SIL
+                INC RDI         ; Increment RDI
+                DEC RCX         ; Decrement RCX
+                JMP .loop       ; Repeat the loop
+
+        .done:
+                LEAVE           ; Clean up the stack
+                RET             ; Return to the caller

--- a/tests/functions.h
+++ b/tests/functions.h
@@ -10,5 +10,6 @@
 int my_strlen(char *str);
 char *my_strchr(const char *s, int c);
 char *my_strrchr(const char *s, int c);
+void *my_memset(void *s, int c, size_t n);
 
 void redirect_all_std(void);

--- a/tests/my_memset.c
+++ b/tests/my_memset.c
@@ -1,0 +1,31 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** my_memset
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+void *my_memset(void *s, int c, size_t n)
+{
+    void *handle;
+    void *(*function)(void *, int, size_t);
+    char *error;
+    void *result;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return NULL;
+    };
+    function = dlsym(handle, "memset");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return NULL;
+    }
+    result = function(s, c, n);
+    dlclose(handle);
+    return result;
+}

--- a/tests/tests_memset.c
+++ b/tests/tests_memset.c
@@ -1,0 +1,49 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_memset
+*/
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
+#include "functions.h"
+
+Test(memset, simple_sentence, .init = redirect_all_std)
+{
+    char test[14] = "Hello, World!";
+    void *my_result;
+    void *result;
+    int tmp;
+
+    my_result = my_memset(test, 'a', 5);
+    result = memset(test, 'a', 5);
+    tmp = memcmp(my_result, result, 5);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memset, size_0, .init = redirect_all_std)
+{
+    char test[14] = "Hello, World!";
+    void *my_result;
+    void *result;
+    int tmp;
+
+    my_result = my_memset(test, 'a', 0);
+    result = memset(test, 'a', 0);
+    tmp = memcmp(my_result, result, 0);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memset, full_sentence, .init = redirect_all_std)
+{
+    char test[14] = "Hello, World!";
+    void *my_result;
+    void *result;
+    int tmp;
+
+    my_result = my_memset(test, 'a', 13);
+    result = memset(test, 'a', 1);
+    tmp = memcmp(my_result, result, 13);
+    cr_assert_eq(tmp, 0);
+}


### PR DESCRIPTION
The `memset` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asm
BITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL memset        ; export "memset"

memset:
        ENTER 0, 0       ; starts the program
        MOV RCX, RDX    ; Move the value of RDX into RCX

        .loop:
                CMP RCX, 0      ; If RCX is 0, we are done
                JE .done
                MOV BYTE [RDI], SIL ; Set the memory at RDI to the value of SIL
                INC RDI         ; Increment RDI
                DEC RCX         ; Decrement RCX
                JMP .loop       ; Repeat the loop

        .done:
                LEAVE           ; Clean up the stack
                RET             ; Return to the caller
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/2a0e3783-2431-47c0-8905-2b4754082e0a)