### PR TITLE
🧱 Remove useless include from tests file and add it in the header file

### DIFF
--- a/tests/functions.h
+++ b/tests/functions.h
@@ -8,11 +8,7 @@
 #pragma once
 
 #include <dlfcn.h>
-
-int my_strlen(char *str);
-char *my_strchr(const char *s, int c);
-char *my_strrchr(const char *s, int c);
-void *my_memset(void *s, int c, size_t n);
-void *my_memcpy(void *restrict dest, const void *restrict src, size_t n);
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>
 
 void redirect_all_std(void);

--- a/tests/tests_memcpy.c
+++ b/tests/tests_memcpy.c
@@ -5,8 +5,6 @@
 ** tests_memset
 */
 
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 #include "functions.h"
 
 void *my_memcpy(void *restrict dest, const void *restrict src, size_t n)

--- a/tests/tests_memset.c
+++ b/tests/tests_memset.c
@@ -5,8 +5,6 @@
 ** tests_memset
 */
 
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 #include "functions.h"
 
 void *my_memset(void *s, int c, size_t n)

--- a/tests/tests_strchr.c
+++ b/tests/tests_strchr.c
@@ -5,8 +5,6 @@
 ** tests_strchr
 */
 
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 #include "functions.h"
 
 char *my_strchr(const char *s, int c)

--- a/tests/tests_strlen.c
+++ b/tests/tests_strlen.c
@@ -5,8 +5,6 @@
 ** strlen
 */
 
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 #include "functions.h"
 
 int my_strlen(char *str)

--- a/tests/tests_strrchr.c
+++ b/tests/tests_strrchr.c
@@ -5,8 +5,6 @@
 ** tests_strrchr
 */
 
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 #include "functions.h"
 
 char *my_strrchr(const char *s, int c)


### PR DESCRIPTION
Remove criterion includes and `dlopen` / `dlsym` lib includes from all the test files to group it in the header file
Here's the header file:
```c
/*
** EPITECH PROJECT, 2024
** MiniLibC
** File description:
** functions
*/

#pragma once

#include <dlfcn.h>
#include <criterion/criterion.h>
#include <criterion/redirect.h>

void redirect_all_std(void);
```