### PR TITLE
:sparkles: Implement strcmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ SRC	=	src/strlen.asm		\
 		src/strrchr.asm		\
 		src/memset.asm		\
 		src/memcpy.asm		\
+		src/strcmp.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -32,6 +33,7 @@ TEST_SRC	=	tests/tests_strlen.c	\
 				tests/tests_strrchr.c	\
 				tests/tests_memset.c	\
 				tests/tests_memcpy.c	\
+				tests/tests_strcmp.c	\
 
 .PHONY:	all clean fclean re
 

--- a/src/memcpy.asm
+++ b/src/memcpy.asm
@@ -10,8 +10,8 @@ memcpy:
         .loop:
                 CMP RCX, 0      ; If length is 0, we're done
                 JE .done
-                MOV BYTE [RSI], R8B ; Copy the byte to a tmp register
-                MOV BYTE [RDI], R8B ; Copy the byte to the destination
+                MOV R8B, BYTE [RSI]   ; Copy the byte to a tmp register
+                MOV BYTE [RDI], R8B   ; Copy the byte to the destination
                 INC RDI         ; Move source pointer
                 INC RSI         ; Move destination pointer
                 DEC RCX         ; Decrement length

--- a/src/strcmp.asm
+++ b/src/strcmp.asm
@@ -1,0 +1,31 @@
+BITS 64                 ; 64-bit mode
+SECTION .text           ; Code section
+GLOBAL strcmp        ; export "strcmp"
+
+strcmp:
+        ENTER 0, 0      ; Prologue
+        MOV RCX, 0      ; Initialize counter
+        XOR R8, R8      ; Clear R8
+        XOR R9, R9      ; Clear R9
+
+        .loop:
+                MOV R8B, BYTE [RDI] ; Load byte from first string
+                MOV R9B, BYTE [RSI] ; Load byte from second string
+                CMP R8B, R9B        ; Compare bytes
+                JE .are_equal           ; If not equal, jump to done
+                MOV RAX, R8        ; Move byte to RAX
+                SUB RAX, R9        ; Subtract second byte from first byte
+                LEAVE               ; Epilogue
+                RET                 ; Return
+
+        .are_equal:
+                CMP R8B, 0      ; Check for null terminator
+                JE .exit        ; If null terminator, jump to exit
+                INC RDI         ; Increment first string pointer
+                INC RSI         ; Increment second string pointer
+                JMP .loop       ; Jump to loop
+
+        .exit:
+                MOV RAX, RCX    ; Return counter
+                LEAVE           ; Epilogue
+                RET             ; Return

--- a/tests/tests_strcmp.c
+++ b/tests/tests_strcmp.c
@@ -1,0 +1,80 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_strcmp
+*/
+
+#include "functions.h"
+
+int my_strcmp(const char *s1, const char *s2)
+{
+    void *handle;
+    int (*function)(const char *, const char *);
+    char *error;
+    int result;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return 84;
+    };
+    function = dlsym(handle, "strcmp");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return 84;
+    }
+    result = function(s1, s2);
+    dlclose(handle);
+    return result;
+}
+
+Test(my_strcmp, simple_sentence, .init = redirect_all_std)
+{
+    char *s1 = "Hello, world!";
+    char *s2 = "Hello, world!";
+    int my_result = my_strcmp(s1, s2);
+    int result = strcmp(s1, s2);
+
+    cr_assert_eq(my_result, result);
+}
+
+Test(my_strcmp, no_sentence, .init = redirect_all_std)
+{
+    char *s1 = "";
+    char *s2 = "";
+    int my_result = my_strcmp(s1, s2);
+    int result = strcmp(s1, s2);
+
+    cr_assert_eq(my_result, result);
+}
+
+Test(my_strcmp, different_sentence, .init = redirect_all_std)
+{
+    char *s1 = "Hello, world!";
+    char *s2 = "Hello, world";
+    int my_result = my_strcmp(s1, s2);
+    int result = strcmp(s1, s2);
+
+    cr_assert_eq(my_result, result);
+}
+
+Test(my_strcmp, one_sentence_empty, .init = redirect_all_std)
+{
+    char *s1 = "Hello, world!";
+    char *s2 = "";
+    int my_result = my_strcmp(s1, s2);
+    int result = strcmp(s1, s2);
+
+    cr_assert_eq(my_result, result);
+}
+
+Test(my_strcmp, one_sentence_empty2, .init = redirect_all_std)
+{
+    char *s1 = "";
+    char *s2 = "Hello, world!";
+    int my_result = my_strcmp(s1, s2);
+    int result = strcmp(s1, s2);
+
+    cr_assert_eq(my_result, result);
+}


### PR DESCRIPTION
The `strcmp` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asmBITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL strcmp        ; export "strcmp"

strcmp:
        ENTER 0, 0      ; Prologue
        MOV RCX, 0      ; Initialize counter
        XOR R8, R8      ; Clear R8
        XOR R9, R9      ; Clear R9

        .loop:
                MOV R8B, BYTE [RDI] ; Load byte from first string
                MOV R9B, BYTE [RSI] ; Load byte from second string
                CMP R8B, R9B        ; Compare bytes
                JE .are_equal           ; If not equal, jump to done
                MOV RAX, R8        ; Move byte to RAX
                SUB RAX, R9        ; Subtract second byte from first byte
                LEAVE               ; Epilogue
                RET                 ; Return

        .are_equal:
                CMP R8B, 0      ; Check for null terminator
                JE .exit        ; If null terminator, jump to exit
                INC RDI         ; Increment first string pointer
                INC RSI         ; Increment second string pointer
                JMP .loop       ; Jump to loop

        .exit:
                MOV RAX, RCX    ; Return counter
                LEAVE           ; Epilogue
                RET             ; Return
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/9da479a0-9c4b-4f68-9b1a-4cf9d19c318d)