### PR TITLE
:sparkles: Implement strncmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SRC	=	src/strlen.asm		\
 		src/memset.asm		\
 		src/memcpy.asm		\
 		src/strcmp.asm		\
+		src/strncmp.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -34,6 +35,7 @@ TEST_SRC	=	tests/tests_strlen.c	\
 				tests/tests_memset.c	\
 				tests/tests_memcpy.c	\
 				tests/tests_strcmp.c	\
+				tests/tests_strncmp.c	\
 
 .PHONY:	all clean fclean re
 

--- a/src/strcmp.asm
+++ b/src/strcmp.asm
@@ -12,7 +12,7 @@ strcmp:
                 MOV R8B, BYTE [RDI] ; Load byte from first string
                 MOV R9B, BYTE [RSI] ; Load byte from second string
                 CMP R8B, R9B        ; Compare bytes
-                JE .are_equal           ; If not equal, jump to done
+                JE .are_equal           ; If not equal, jump to are_equal
                 MOV RAX, R8        ; Move byte to RAX
                 SUB RAX, R9        ; Subtract second byte from first byte
                 LEAVE               ; Epilogue

--- a/src/strncmp.asm
+++ b/src/strncmp.asm
@@ -1,0 +1,34 @@
+BITS 64                 ; 64-bit mode
+SECTION .text           ; Code section
+GLOBAL strncmp        ; export "strncmp"
+
+strncmp:
+        ENTER 0, 0      ; Prologue
+        MOV RCX, 0      ; Initialize counter
+        XOR R8, R8      ; Clear R8
+        XOR R9, R9      ; Clear R9
+
+        .loop:
+                CMP RDX, 0      ; Check for null terminator
+                JE .exit        ; If null terminator, jump to exit
+                MOV R8B, BYTE [RDI] ; Load byte from first string
+                MOV R9B, BYTE [RSI] ; Load byte from second string
+                CMP R8B, R9B        ; Compare bytes
+                JE .are_equal           ; If not equal, jump to are_equal
+                MOV RAX, R8        ; Move byte to RAX
+                SUB RAX, R9        ; Subtract second byte from first byte
+                LEAVE               ; Epilogue
+                RET                 ; Return
+
+        .are_equal:
+                CMP R8B, 0      ; Check for null terminator
+                JE .exit        ; If null terminator, jump to exit
+                INC RDI         ; Increment first string pointer
+                INC RSI         ; Increment second string pointer
+                DEC RDX         ; Decrement counter
+                JMP .loop       ; Jump to loop
+
+        .exit:
+                MOV RAX, RCX    ; Return counter
+                LEAVE           ; Epilogue
+                RET             ; Return

--- a/tests/tests_strncmp.c
+++ b/tests/tests_strncmp.c
@@ -1,0 +1,146 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_strcmp
+*/
+
+#include "functions.h"
+
+int my_strncmp(const char *s1, const char *s2, size_t n)
+{
+    void *handle;
+    int (*function)(const char *, const char *, size_t);
+    char *error;
+    int result;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return 84;
+    };
+    function = dlsym(handle, "strncmp");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return 84;
+    }
+    result = function(s1, s2, n);
+    dlclose(handle);
+    return result;
+}
+
+Test(my_strncmp, simple_sentence, .init = redirect_all_std)
+{
+    char *s1 = "Hello, world!";
+    char *s2 = "Hello, world!";
+    int my_result = my_strncmp(s1, s2, 13);
+    int result = strncmp(s1, s2, 13);
+
+    cr_assert_eq(my_result, result);
+}
+
+Test(my_strncmp, no_string, .init = redirect_all_std)
+{
+    char *s1 = "";
+    char *s2 = "";
+    int my_result = my_strncmp(s1, s2, 0);
+    int result = strncmp(s1, s2, 0);
+
+    cr_assert_eq(my_result, result);
+}
+
+Test(my_strncmp, no_string2, .init = redirect_all_std)
+{
+    char *s1 = "";
+    char *s2 = "";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 10));
+    sprintf(s4, "%d", strncmp(s1, s2, 10));
+    cr_assert_str_eq(s3, s4);
+}
+
+Test(my_strncmp, empty_string, .init = redirect_all_std)
+{
+    char *s1 = "g";
+    char *s2 = "g";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 2));
+    sprintf(s4, "%d", strncmp(s1, s2, 2));
+    cr_assert_str_eq(s3, s4);
+}
+
+Test(my_strncmp, different_string, .init = redirect_all_std)
+{
+    char *s1 = "!Hello, world!";
+    char *s2 = ";Hello, world!";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 5));
+    sprintf(s4, "%d", strncmp(s1, s2, 5));
+    cr_assert_str_eq(s3, s4);
+}
+
+Test(my_strncmp, different_string2, .init = redirect_all_std)
+{
+    char *s1 = "Hell";
+    char *s2 = "Hell!";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 10));
+    sprintf(s4, "%d", strncmp(s1, s2, 10));
+    cr_assert_str_eq(s3, s4);
+}
+
+Test(my_strncmp, different_string3, .init = redirect_all_std)
+{
+    char *s1 = "Hello, world!";
+    char *s2 = "Hello, world";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 13));
+    sprintf(s4, "%d", strncmp(s1, s2, 13));
+    cr_assert_str_eq(s3, s4);
+}
+
+Test(my_strncmp, one_string_empty, .init = redirect_all_std)
+{
+    char *s1 = "Hello, world!";
+    char *s2 = "";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 13));
+    sprintf(s4, "%d", strncmp(s1, s2, 13));
+    cr_assert_str_eq(s3, s4);
+}
+
+Test(my_strncmp, one_string_empty2, .init = redirect_all_std)
+{
+    char *s1 = "";
+    char *s2 = "Hello, world!";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 13));
+    sprintf(s4, "%d", strncmp(s1, s2, 13));
+    cr_assert_str_eq(s3, s4);
+}
+
+Test(my_strncmp, one_string_empty3, .init = redirect_all_std)
+{
+    char *s1 = "Hello, world!";
+    char *s2 = "Hello, world!";
+    char s3[100];
+    char s4[100];
+
+    sprintf(s3, "%d", my_strncmp(s1, s2, 3));
+    sprintf(s4, "%d", strncmp(s1, s2, 3));
+    cr_assert_str_eq(s3, s4);
+}


### PR DESCRIPTION
The `strncmp` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asm
BITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL strncmp        ; export "strncmp"

strncmp:
        ENTER 0, 0      ; Prologue
        MOV RCX, 0      ; Initialize counter
        XOR R8, R8      ; Clear R8
        XOR R9, R9      ; Clear R9

        .loop:
                CMP RDX, 0      ; Check for null terminator
                JE .exit        ; If null terminator, jump to exit
                MOV R8B, BYTE [RDI] ; Load byte from first string
                MOV R9B, BYTE [RSI] ; Load byte from second string
                CMP R8B, R9B        ; Compare bytes
                JE .are_equal           ; If not equal, jump to are_equal
                MOV RAX, R8        ; Move byte to RAX
                SUB RAX, R9        ; Subtract second byte from first byte
                LEAVE               ; Epilogue
                RET                 ; Return

        .are_equal:
                CMP R8B, 0      ; Check for null terminator
                JE .exit        ; If null terminator, jump to exit
                INC RDI         ; Increment first string pointer
                INC RSI         ; Increment second string pointer
                DEC RDX         ; Decrement counter
                JMP .loop       ; Jump to loop

        .exit:
                MOV RAX, RCX    ; Return counter
                LEAVE           ; Epilogue
                RET             ; Return
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/3427ebe4-b3ff-4be5-bce0-e5c16ef159e7)