### PR TITLE
:sparkles: Implement memmove

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SRC	=	src/strlen.asm		\
 		src/memset.asm		\
 		src/memcpy.asm		\
 		src/strcmp.asm		\
+		src/memmove.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -34,6 +35,7 @@ TEST_SRC	=	tests/tests_strlen.c	\
 				tests/tests_memset.c	\
 				tests/tests_memcpy.c	\
 				tests/tests_strcmp.c	\
+				tests/tests_memmove.c	\
 
 .PHONY:	all clean fclean re
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ TEST_SRC	=	tests/tests_strlen.c	\
 				tests/tests_memset.c	\
 				tests/tests_memcpy.c	\
 				tests/tests_strcmp.c	\
+				tests/tests_memmove.c	\
+				tests/tests_strncmp.c	\
+				tests/tests_strcasecmp.c\
 
 .PHONY:	all clean fclean re
 

--- a/src/memmove.asm
+++ b/src/memmove.asm
@@ -1,0 +1,29 @@
+BITS 64                 ; 64-bit mode
+SECTION .text           ; Code section
+GLOBAL memmove          ; export "memmove"
+
+memmove:
+        ENTER 0,0       ; Prologue
+        MOV RCX, 0      ; Initialize counter
+        MOV R8, RDI     ; Save destination pointer
+
+        .get_string:    ; Get copy of source
+                CMP RCX, RDX                    ; Compare counter with length
+                JE .set_string                  ; If equal, the string is copied
+                MOV R9B, [RSI + RCX]            ; Move byte from source to destination
+                MOV BYTE [R8 + RCX], R9B        ; Move byte from source to destination
+                INC RCX                         ; Increment counter
+                JMP .get_string                 ; Jump to loop
+
+        .set_string:    ; Set the dest to the copy of the source
+                XOR RCX, RCX                    ; Reset counter
+                CMP RCX, RDX                    ; Compare counter with length
+                JE .end                         ; If equal, jump to end
+                MOV R9B, [R8 + RCX]             ; Move byte from source to destination
+                MOV BYTE [RAX + RCX], R9B       ; Move byte from source to destination
+                INC RCX                         ; Increment counter
+                JMP .set_string                 ; Jump to set_string
+
+        .end:
+                LEAVE                           ; Epilogue
+                RET                             ; Return

--- a/tests/tests_memmove.c
+++ b/tests/tests_memmove.c
@@ -1,0 +1,133 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_memmove
+*/
+
+#include "functions.h"
+
+void *my_memmove(void *dest, const void *src, size_t n)
+{
+    void *handle;
+    void *(*my_memmove)(void *restrict, const void *restrict, size_t);
+    char *error;
+
+    handle = dlopen("libc.so.6", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return NULL;
+    }
+    my_memmove = dlsym(handle, "memmove");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return NULL;
+    }
+    my_memmove(dest, src, n);
+    dlclose(handle);
+    return dest;
+}
+
+Test(memmove, basic_test)
+{
+    char *src = "Hello World";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 12);
+    tmp = memcmp(dest, src, 12);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, size_0)
+{
+    char *src = "Hello World";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 0);
+    tmp = memcmp(dest, src, 0);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, no_string)
+{
+    char *src = "";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 1);
+    tmp = memcmp(dest, src, 1);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, no_string_2)
+{
+    char *src = "";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 0);
+    tmp = memcmp(dest, src, 0);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, overlap)
+{
+    char *src = "Hello World";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 12);
+    my_memmove(dest + 5, dest, 5);
+    tmp = memcmp(dest, "HelloHello", 10);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, overlap_2)
+{
+    char *src = "Hello World";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 12);
+    my_memmove(dest + 6, dest, 5);
+    tmp = memcmp(dest, "Hello Hello", 11);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, overlap_3)
+{
+    char *src = "Hello World";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 12);
+    my_memmove(dest + 7, dest, 5);
+    tmp = memcmp(dest, "Hello WHello", 11);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, negative_overlap)
+{
+    char *src = "Hello World";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 12);
+    my_memmove(dest, dest + 5, 5);
+    tmp = memcmp(dest, " Worl World", 7);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, negative_overlap_2)
+{
+    char *src = "Hello World";
+    char dest[12];
+    int tmp;
+
+    my_memmove(dest, src, 12);
+    my_memmove(dest, dest + 1, 0);
+    tmp = memcmp(dest, "Hello World", 12);
+    cr_assert_eq(tmp, 0);
+}


### PR DESCRIPTION
The `memmove` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asm
BITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL memmove          ; export "memmove"

memmove:
        ENTER 0,0       ; Prologue
        MOV RCX, 0      ; Initialize counter
        MOV R8, RDI     ; Save destination pointer

        .get_string:    ; Get copy of source
                CMP RCX, RDX                    ; Compare counter with length
                JE .set_string                  ; If equal, the string is copied
                MOV R9B, [RSI + RCX]            ; Move byte from source to destination
                MOV BYTE [R8 + RCX], R9B        ; Move byte from source to destination
                INC RCX                         ; Increment counter
                JMP .get_string                 ; Jump to loop

        .set_string:    ; Set the dest to the copy of the source
                XOR RCX, RCX                    ; Reset counter
                CMP RCX, RDX                    ; Compare counter with length
                JE .end                         ; If equal, jump to end
                MOV R9B, [R8 + RCX]             ; Move byte from source to destination
                MOV BYTE [RAX + RCX], R9B       ; Move byte from source to destination
                INC RCX                         ; Increment counter
                JMP .set_string                 ; Jump to set_string

        .end:
                LEAVE                           ; Epilogue
                RET                             ; Return
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/160fae80-9747-4f49-a77b-c1e3f229d6ab)