### PR TITLE
:sparkles: Implement strpbrk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ SRC	=	src/strlen.asm		\
 		src/memmove.asm		\
 		src/strncmp.asm		\
 		src/strcasecmp.asm	\
+		src/strncmp.asm	\
+		src/strpbrk.asm	\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -40,6 +42,8 @@ TEST_SRC	=	tests/tests_strlen.c	\
 				tests/tests_memmove.c	\
 				tests/tests_strncmp.c	\
 				tests/tests_strcasecmp.c\
+				tests/tests_memmove.c	\
+				tests/tests_strstr.c	\
 
 .PHONY:	all clean fclean re
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SRC	=	src/strlen.asm		\
 		src/strcasecmp.asm	\
 		src/strncmp.asm		\
 		src/strstr.asm		\
-		src/strpbrk.asm	\
+		src/strpbrk.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -43,6 +43,7 @@ TEST_SRC	=	tests/tests_strlen.c	\
 				tests/tests_strcasecmp.c\
 				tests/tests_memmove.c	\
 				tests/tests_strstr.c	\
+				tests/tests_strpbrk.c	\
 
 .PHONY:	all clean fclean re
 

--- a/src/strpbrk.asm
+++ b/src/strpbrk.asm
@@ -1,0 +1,4 @@
+BITS 64                 ; 64-bit mode
+SECTION .text           ; Code section
+GLOBAL strpbrk           ; export "strpbrk"
+strpbrk:

--- a/src/strpbrk.asm
+++ b/src/strpbrk.asm
@@ -2,3 +2,37 @@ BITS 64                 ; 64-bit mode
 SECTION .text           ; Code section
 GLOBAL strpbrk           ; export "strpbrk"
 strpbrk:
+        ENTER 0, 0      ; Prolog
+        MOV RCX, 0      ; Initialize counter
+        CMP RSI, 0      ; Check for NULL pointer
+        JE .not_found   ; If NULL, return NULL
+        JMP .loop       ; Jump to loop
+
+        .loop:
+                CMP BYTE [RDI], 0 ; Check for null terminator
+                JE .not_found           ; If null terminator, return NULL
+                JMP .compare           ; Jump to compare
+
+        .compare:
+                CMP BYTE [RSI + RCX], 0 ; Check for null terminator
+                JE .next               ; If null terminator, jump to next
+                MOV R8B, BYTE [RSI + RCX] ; Load character from second string
+                CMP BYTE [RDI], R8B ; Compare character
+                JE .exit              ; If equal, jump to exit
+                INC RCX               ; Increment counter
+                JMP .compare          ; Jump to compare
+
+        .next:
+                INC RDI                 ; Increment pointer to character
+                XOR RCX, RCX            ; Reset first counter
+                JMP .loop               ; Jump to loop
+
+        .not_found:
+                MOV RAX, 0              ; Return NULL
+                LEAVE                   ; Epilog
+                RET                     ; Return
+
+        .exit:
+                MOV RAX, RDI          ; Return pointer to character
+                LEAVE                 ; Epilog
+                RET                   ; Return

--- a/src/strstr.asm
+++ b/src/strstr.asm
@@ -3,7 +3,7 @@ SECTION .text           ; Code section
 GLOBAL strstr           ; export "strstr"
 
 strstr:
-        ENTER 0, 0      ; Prologue
+        ENTER 0, 0      ; Prolog
         MOV RCX, 0      ; Initialize the counter
         MOV RDX, 0      ; Initialize the second counter
         JMP .loop

--- a/tests/tests_strpbrk.c
+++ b/tests/tests_strpbrk.c
@@ -12,6 +12,7 @@ char *my_strpbrk(const char *s, const char *accept)
     char *handle;
     char *(*my_strpbrk)(const char *, const char *);
     char *error;
+    char *result;
 
     handle = dlopen("./libasm.so", RTLD_LAZY);
     if (!handle) {
@@ -23,16 +24,112 @@ char *my_strpbrk(const char *s, const char *accept)
         fprintf(stderr, "%s\n", error);
         return NULL;
     }
-    my_strpbrk(s, accept);
+    result = my_strpbrk(s, accept);
     dlclose(handle);
-    return my_strpbrk(s, accept);
+    return result;
 }
 
 Test(strpbrk, simple_sentence)
 {
-    char *src = "Hello";
-    char *tmp;
+    char *test = "Hello, World!";
+    char *my_result;
+    char *result;
 
-    tmp = my_strpbrk(src, "l");
-    cr_assert_str_eq(tmp, "llo");
+    my_result = my_strpbrk(test, "World");
+    result = strpbrk(test, "World");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, long_sentence)
+{
+    char *test = "lorem ipsum dolor sit amet, consectetur adipiscing elit.\
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi\
+    ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit\
+    in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur\
+    sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt\
+    mollit anim id est laborum.";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "ipsum");
+    result = strpbrk(test, "ipsum");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, not_found)
+{
+    char *test = "Hello, World!";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "zwv.yx");
+    result = strpbrk(test, "zwv.yx");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, empty_string)
+{
+    char *test = "";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "World");
+    result = strpbrk(test, "World");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, empty_accept)
+{
+    char *test = "Hello, World!";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "");
+    result = strpbrk(test, "");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, empty_string_and_accept)
+{
+    char *test = "";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "");
+    result = strpbrk(test, "");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, zero_ended_string)
+{
+    char *test = "Hello, World!\0";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "World");
+    result = strpbrk(test, "World");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, zero_ended_string_only)
+{
+    char *test = "";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "\0");
+    result = strpbrk(test, "\0");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strpbrk, zero_ended_string_accept)
+{
+    char *test = "Hello, World!";
+    char *my_result;
+    char *result;
+
+    my_result = my_strpbrk(test, "\0");
+    result = strpbrk(test, "\0");
+    cr_assert_eq(my_result, result);
 }

--- a/tests/tests_strpbrk.c
+++ b/tests/tests_strpbrk.c
@@ -1,0 +1,38 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_strpbrk
+*/
+
+#include "functions.h"
+
+char *my_strpbrk(const char *s, const char *accept)
+{
+    char *handle;
+    char *(*my_strpbrk)(const char *, const char *);
+    char *error;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return NULL;
+    }
+    my_strpbrk = dlsym(handle, "strpbrk");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return NULL;
+    }
+    my_strpbrk(s, accept);
+    dlclose(handle);
+    return my_strpbrk(s, accept);
+}
+
+Test(strpbrk, simple_sentence)
+{
+    char *src = "Hello";
+    char *tmp;
+
+    tmp = my_strpbrk(src, "l");
+    cr_assert_str_eq(tmp, "llo");
+}

--- a/tests/tests_strstr.c
+++ b/tests/tests_strstr.c
@@ -1,0 +1,38 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_strstr
+*/
+
+#include "functions.h"
+
+char *my_strstr(const char *haystack, const char *needle)
+{
+    char *handle;
+    char *(*my_strstr)(const char *, const char *);
+    char *error;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return NULL;
+    }
+    my_strstr = dlsym(handle, "strstr");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return NULL;
+    }
+    my_strstr(haystack, needle);
+    dlclose(handle);
+    return my_strstr(haystack, needle);
+}
+
+Test(strstr, simple_sentence, .init = redirect_all_std)
+{
+    char *src = "Hello";
+    char *tmp;
+
+    tmp = my_strstr(src, "l");
+    cr_assert_str_eq(tmp, "llo");
+}


### PR DESCRIPTION
The `strpbrk` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asm
BITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL strpbrk           ; export "strpbrk"
strpbrk:
        ENTER 0, 0      ; Prolog
        MOV RCX, 0      ; Initialize counter
        CMP RSI, 0      ; Check for NULL pointer
        JE .not_found   ; If NULL, return NULL
        JMP .loop       ; Jump to loop

        .loop:
                CMP BYTE [RDI], 0 ; Check for null terminator
                JE .not_found           ; If null terminator, return NULL
                JMP .compare           ; Jump to compare

        .compare:
                CMP BYTE [RSI + RCX], 0 ; Check for null terminator
                JE .next               ; If null terminator, jump to next
                MOV R8B, BYTE [RSI + RCX] ; Load character from second string
                CMP BYTE [RDI], R8B ; Compare character
                JE .exit              ; If equal, jump to exit
                INC RCX               ; Increment counter
                JMP .compare          ; Jump to compare

        .next:
                INC RDI                 ; Increment pointer to character
                XOR RCX, RCX            ; Reset first counter
                JMP .loop               ; Jump to loop

        .not_found:
                MOV RAX, 0              ; Return NULL
                LEAVE                   ; Epilog
                RET                     ; Return

        .exit:
                MOV RAX, RDI          ; Return pointer to character
                LEAVE                 ; Epilog
                RET                   ; Return
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/0deaf2a1-1e44-4f96-9a87-178ee2a22055)