### PR TITLE
:sparkles: Implement strcspn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SRC	=	src/strlen.asm		\
 		src/strncmp.asm		\
 		src/strstr.asm		\
 		src/strpbrk.asm		\
+		src/strcspn.asm		\
 
 OBJ	= $(SRC:.asm=.o)
 
@@ -44,6 +45,7 @@ TEST_SRC	=	tests/tests_strlen.c	\
 				tests/tests_memmove.c	\
 				tests/tests_strstr.c	\
 				tests/tests_strpbrk.c	\
+				tests/tests_strcspn.c	\
 
 .PHONY:	all clean fclean re
 

--- a/src/strcspn.asm
+++ b/src/strcspn.asm
@@ -1,0 +1,55 @@
+SECTION .text           ; Code section
+GLOBAL strcspn          ; export "strcspn"
+
+strcspn:
+        ENTER 0, 0          ; Prolog
+        CALL strlen         ; Call strlen to get length of first string
+        XOR RCX, RCX        ; Initialize first counter
+        MOV RDX, RAX        ; Move length of first string to RDX
+        MOV R9, 0           ; Initialize second counter
+        JMP .loop            ; Jump to loop
+
+        .loop:
+                CMP BYTE [RDI], 0               ; Check for null terminator
+                JE .end                 ; If null terminator, return length of string
+                JMP .compare                    ; Jump to compare
+
+        .compare:
+                CMP BYTE [RSI + RCX], 0         ; Check for null terminator
+                JE .next                        ; If null terminator, return length of string
+                MOV R8B, BYTE [RSI + RCX]       ; Load character from second string
+                CMP BYTE [RDI], R8B             ; Compare c from first string with c from second string
+                JE .found                       ; If equal, return length of string
+                INC RCX                         ; Increment first counter
+                JMP .compare
+
+        .next:
+                INC R9                          ; Increment second counter
+                INC RDI                         ; Increment pointer to second string
+                MOV RCX, 0                      ; Reset first counter
+                JMP .loop                        ; Jump to loop
+
+        .found:
+                MOV RAX, R9                     ; Return length of string
+                LEAVE                           ; Epilog
+                RET                             ; Return
+
+        .end:
+                MOV RAX, RDX                    ; Return length of string
+                LEAVE                           ; Epilog
+                RET                             ; Return
+
+strlen:
+        ENTER 0, 0          ; Starts the program
+        MOV RCX, 0          ; Initializes the counter
+
+        .loop_strlen:
+                CMP BYTE [RDI + RCX], 0         ; Checks if the character is null
+                JE .end_strlen                  ; True -> jumps to the end
+                INC RCX                         ; False -> increments the length = the result
+                JMP .loop_strlen                ; Jumps to the loop
+
+        .end_strlen:
+                MOV RAX, RCX                    ; Moves the length to RAX
+                LEAVE                           ; Ends the program
+                RET                             ; Returns the length of the string

--- a/tests/tests_strcspn.c
+++ b/tests/tests_strcspn.c
@@ -160,4 +160,3 @@ Test(strcspn, zero_ended_string_reject2)
     result = strcspn(test, "\0");
     cr_assert_eq(my_result, result);
 }
-m

--- a/tests/tests_strcspn.c
+++ b/tests/tests_strcspn.c
@@ -1,0 +1,163 @@
+/*
+** EPITECH PROJECT, 2024
+** MiniLibC
+** File description:
+** tests_strcspn
+*/
+
+#include "functions.h"
+
+size_t my_strcspn(const char *s, const char *reject)
+{
+    void *handle;
+    size_t (*my_strcspn)(const char *, const char *);
+    char *error;
+    size_t result;
+
+    handle = dlopen("./libasm.so", RTLD_LAZY);
+    if (!handle) {
+        fprintf(stderr, "%s\n", dlerror());
+        return 0;
+    }
+    my_strcspn = dlsym(handle, "strcspn");
+    if ((error = dlerror()) != NULL) {
+        fprintf(stderr, "%s\n", error);
+        return 0;
+    }
+    result = my_strcspn(s, reject);
+    dlclose(handle);
+    return result;
+}
+
+Test(strcspn, simple_string)
+{
+    char *test = "Hello, World!";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "World");
+    result = strcspn(test, "World");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, simple_string2)
+{
+    char *test = "Hello, World!";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "o");
+    result = strcspn(test, "o");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, simple_string3)
+{
+    char *test = "Hello, World!";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "zwh");
+    result = strcspn(test, "zwh");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, no_reject)
+{
+    char *test = "Hello, World!";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "");
+    result = strcspn(test, "");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, no_string)
+{
+    char *test = "";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "World");
+    result = strcspn(test, "World");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, no_string_no_reject)
+{
+    char *test = "";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "");
+    result = strcspn(test, "");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, zero_ended_string)
+{
+    char *test = "Hello, World!\0";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "World");
+    result = strcspn(test, "World");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, zero_ended_string2)
+{
+    char *test = "Hello, World!\0";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "o");
+    result = strcspn(test, "o");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, zero_ended_reject)
+{
+    char *test = "Hello, World!";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "World\0");
+    result = strcspn(test, "World\0");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, zero_ended_reject2)
+{
+    char *test = "Hello, World!";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "o\0");
+    result = strcspn(test, "o\0");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, zero_ended_string_reject)
+{
+    char *test = "Hello, World!\0";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "\0");
+    result = strcspn(test, "\0");
+    cr_assert_eq(my_result, result);
+}
+
+Test(strcspn, zero_ended_string_reject2)
+{
+    char *test = "\0";
+    size_t my_result;
+    size_t result;
+
+    my_result = my_strcspn(test, "\0");
+    result = strcspn(test, "\0");
+    cr_assert_eq(my_result, result);
+}
+m


### PR DESCRIPTION
The `strcspn` function is implement, fully commented and tested completely (except the crash).
Here's the function in asm:
```asm
SECTION .text           ; Code section
GLOBAL strcspn          ; export "strcspn"

strcspn:
        ENTER 0, 0          ; Prolog
        CALL strlen         ; Call strlen to get length of first string
        XOR RCX, RCX        ; Initialize first counter
        MOV RDX, RAX        ; Move length of first string to RDX
        MOV R9, 0           ; Initialize second counter
        JMP .loop            ; Jump to loop

        .loop:
                CMP BYTE [RDI], 0               ; Check for null terminator
                JE .end                 ; If null terminator, return length of string
                JMP .compare                    ; Jump to compare

        .compare:
                CMP BYTE [RSI + RCX], 0         ; Check for null terminator
                JE .next                        ; If null terminator, return length of string
                MOV R8B, BYTE [RSI + RCX]       ; Load character from second string
                CMP BYTE [RDI], R8B             ; Compare c from first string with c from second string
                JE .found                       ; If equal, return length of string
                INC RCX                         ; Increment first counter
                JMP .compare

        .next:
                INC R9                          ; Increment second counter
                INC RDI                         ; Increment pointer to second string
                MOV RCX, 0                      ; Reset first counter
                JMP .loop                        ; Jump to loop

        .found:
                MOV RAX, R9                     ; Return length of string
                LEAVE                           ; Epilog
                RET                             ; Return

        .end:
                MOV RAX, RDX                    ; Return length of string
                LEAVE                           ; Epilog
                RET                             ; Return
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/9a2f12eb-fe97-4cbc-982e-cdd3bc78cc33)