### PR TITLE
:bug: Fix the last strrchr test

### DIFF
--- a/src/strrchr.asm
+++ b/src/strrchr.asm
@@ -5,8 +5,6 @@ GLOBAL strrchr, rindex        ; export "strrchr"
 rindex:
 strrchr:
         ENTER 0, 0       ; starts the program
-        CMP SIL, 0      ; Checks if the character is null
-        JE .end         ; True -> jump to the end
         MOV RCX, 0      ; Initializes the counter
 
         .start_loop:
@@ -16,6 +14,8 @@ strrchr:
                 JMP .start_loop         ; Jumps to itself
 
         .go_to_loop:
+                CMP SIL, 0              ; Checks if it's the end of the string
+                JE .found               ; True -> jump to the found
                 DEC RCX                 ; Decrements the counter
                 JMP .loop               ; Jumps to the loop
 

--- a/tests/tests_strrchr.c
+++ b/tests/tests_strrchr.c
@@ -76,3 +76,9 @@ Test(my_strrchr, empty_source2, .init = redirect_all_std)
     char *test = "\0";
     cr_assert_str_eq(my_strrchr(test, '\0'), strrchr(test, '\0'));
 }
+
+Test(my_strrchr, empty_source3, .init = redirect_all_std)
+{
+    char *test = "Hello, world!";
+    cr_assert_str_eq(my_strrchr(test, '\0'), strrchr(test, '\0'));
+}


### PR DESCRIPTION
I implemented the handling of this test for the `strrchr` function
```c
Test(my_strrchr, empty_source3, .init = redirect_all_std)
{
    char *test = "Hello, world!";
    cr_assert_str_eq(my_strrchr(test, '\0'), strrchr(test, '\0'));
}
```
