### PR TITLE
:white_check_mark: Refactor the memmove function to use the stack

### DIFF
--- a/src/memmove.asm
+++ b/src/memmove.asm
@@ -2,27 +2,29 @@ BITS 64                 ; 64-bit mode
 SECTION .text           ; Code section
 GLOBAL memmove          ; export "memmove"
 
+
 memmove:
-        ENTER 0, 0              ; Prologue
-        XOR RCX, RCX            ; Initialize counter
-        JMP .check_null         ; Jump to check for null pointers
+        ENTER 0, 0              ; Prolog
+        MOV RCX, 0              ; Initialize counter
+        JMP .push_rsi           ; Jump to .push_rsi
 
-        .loop:
-                CMP RDX, RCX            ; Compare counter with length
-                JE .end                 ; Jump to end if equal
-                MOV R10B, [RSI + RCX]   ; Move byte from source to R10B
-                MOV [RDI + RCX], R10B   ; Move byte from R10B to destination
-                INC RCX                 ; Increment counter
-                JMP .loop               ; Jump to loop
+        .push_rsi:
+                CMP RCX, RDX                    ; Compare counter with len
+                JE .pop_rsi                     ; If equals -> jump to .pop_rsi
+                MOV R8B, BYTE [RSI + RCX]       ; Move byte from src to R8B
+                PUSH R8                         ; Push byte to stack
+                INC RCX                         ; Increment counter
+                JMP .push_rsi                   ; Loop
 
-        .check_null:
-                CMP RDI, 0              ; Check if destination pointer is null
-                JE .end                 ; Jump to end if null
-                CMP RSI, 0              ; Check if source pointer is null
-                JE .end                 ; Jump to end if null
-                JMP .loop               ; Jump to compare if not null
+        .pop_rsi:
+                CMP RCX, 0                      ; Compare counter with 0
+                JE .exit                        ; If equals -> jump to .exit
+                POP R8                          ; Pop byte from stack
+                DEC RCX                         ; Decrement counter
+                MOV BYTE [RDI + RCX], R8B       ; Move byte from R8B to dest
+                JMP .pop_rsi                    ; Loop
 
-        .end:
-                MOV RAX, RDI            ; Return destination pointer
-                LEAVE                   ; Epilogue
-                RET                     ; Return
+        .exit:
+                MOV RAX, RDI                    ; Return dest
+                LEAVE                           ; Epilog
+                RET                             ; Return

--- a/tests/tests_memmove.c
+++ b/tests/tests_memmove.c
@@ -131,3 +131,22 @@ Test(memmove, negative_overlap_2)
     tmp = memcmp(dest, "Hello World", 12);
     cr_assert_eq(tmp, 0);
 }
+
+Test(memmove, big_string)
+{
+    char src[800000];
+    char dest[800000];
+    int tmp;
+
+    memset(src, 'a', 800000);
+    memset(dest, 'b', 800000);
+    my_memmove(dest, src, 800000);
+    cr_assert_eq(tmp, 0);
+}
+
+Test(memmove, overlap4)
+{
+    char src[100] = "Geeksfor";
+    my_memmove(src+5, src, strlen(src));
+    cr_assert_str_eq(src, "GeeksGeeksfor");
+}


### PR DESCRIPTION
I refactored the `memmove` function to pass the overlap tests by using the stack.
Here's the function:
```asm
BITS 64                 ; 64-bit mode
SECTION .text           ; Code section
GLOBAL memmove          ; export "memmove"


memmove:
        ENTER 0, 0              ; Prolog
        MOV RCX, 0              ; Initialize counter
        JMP .push_rsi           ; Jump to .push_rsi

        .push_rsi:
                CMP RCX, RDX                    ; Compare counter with len
                JE .pop_rsi                     ; If equals -> jump to .pop_rsi
                MOV R8B, BYTE [RSI + RCX]       ; Move byte from src to R8B
                PUSH R8                         ; Push byte to stack
                INC RCX                         ; Increment counter
                JMP .push_rsi                   ; Loop

        .pop_rsi:
                CMP RCX, 0                      ; Compare counter with 0
                JE .exit                        ; If equals -> jump to .exit
                POP R8                          ; Pop byte from stack
                DEC RCX                         ; Decrement counter
                MOV BYTE [RDI + RCX], R8B       ; Move byte from R8B to dest
                JMP .pop_rsi                    ; Loop

        .exit:
                MOV RAX, RDI                    ; Return dest
                LEAVE                           ; Epilog
                RET                             ; Return
```
And here's the tests:
![image](https://github.com/Thomaltarix/MiniLibC/assets/114673563/f0acf446-90ae-4266-8b55-2420460b80e5)