### PR TITLE
🩹 Fix memmove to pass the big buffer test

### DIFF
--- a/src/memmove.asm
+++ b/src/memmove.asm
@@ -5,66 +5,30 @@ GLOBAL memmove          ; export "memmove"
 memmove:
         ENTER 0, 0       ; Prolog
         MOV RAX, RDI     ; Copy dest to RAX
-        JMP .loop        ; Jump to loop
+        XOR RCX, RCX     ; Initialize counter to 0
 
         .loop:
                 CMP RSI, RDI    ; Compare src with dest
-                JG .memcpy      ; If src > dest -> jump to memcpy
-                CALL .memmove_stack   ; Else call memmove
+                JE .done        ; If equal, we're done
+                JG .forward     ; If src > dest, jump to forward
+                MOV RCX, RDX    ; If src > dest, set counter to length
+                JL .backward    ; If src < dest, jump to backward
 
-        .memmove_stack:
-                CALL memmove_stack ; call memmove_stack
-                JMP .end        ; jump to end
+        .forward:
+                CMP RCX, RDX    ; Compare counter with length
+                JE .done        ; If counter is 0, we're done
+                MOV R8B, BYTE [RSI + RCX] ; Move byte from src to R8B
+                MOV BYTE [RDI + RCX], R8B ; Move byte from R8B to dest
+                INC RCX         ; Increment counter
+                JMP .forward    ; Jump to forward
 
-        .memcpy:
-                CALL memcpy     ; call memcpy
-                JMP .end        ; jump to end
-
-        .end:
-                MOV RAX, RDI    ; return dest
-                LEAVE           ; Epilog
-                RET             ; Return
-
-memmove_stack:
-        ENTER 0, 0              ; Prolog
-        MOV RCX, 0              ; Initialize counter
-        JMP .push_rsi           ; Jump to .push_rsi
-
-        .push_rsi:
-                CMP RCX, RDX                    ; Compare counter with len
-                JE .pop_rsi                     ; If equals -> jump to .pop_rsi
-                MOV R8B, BYTE [RSI + RCX]       ; Move byte from src to R8B
-                PUSH R8                         ; Push byte to stack
-                INC RCX                         ; Increment counter
-                JMP .push_rsi                   ; Loop
-
-        .pop_rsi:
-                CMP RCX, 0                      ; Compare counter with 0
-                JE .exit                        ; If equals -> jump to .exit
-                POP R8                          ; Pop byte from stack
-                DEC RCX                         ; Decrement counter
-                MOV BYTE [RDI + RCX], R8B       ; Move byte from R8B to dest
-                JMP .pop_rsi                    ; Loop
-
-        .exit:
-                MOV RAX, RDI                    ; Return dest
-                LEAVE                           ; Epilog
-                RET                             ; Return
-
-memcpy:
-        ENTER 0, 0      ; Prolog
-        MOV RCX, RDX    ; Copy length to RCX
-        MOV RAX, RDI    ; Copy source to RAX
-
-        .loop:
-                CMP RCX, 0      ; If length is 0, we're done
-                JE .done
-                MOV R8B, BYTE [RSI]   ; Copy the byte to a tmp register
-                MOV BYTE [RDI], R8B   ; Copy the byte to the destination
-                INC RDI         ; Move source pointer
-                INC RSI         ; Move destination pointer
-                DEC RCX         ; Decrement length
-                JMP .loop       ; Repeat
+        .backward:
+                CMP RCX, 0      ; Compare counter with 0
+                JE .done        ; If counter is 0, we're done
+                MOV R8B, BYTE [RSI + RCX - 1] ; Move byte from src to R8B
+                MOV BYTE [RDI + RCX - 1], R8B ; Move byte from R8B to dest
+                DEC RCX         ; Decrement counter
+                JMP .backward   ; Jump to backward
 
         .done:
                 LEAVE           ; Epilog

--- a/src/memmove.asm
+++ b/src/memmove.asm
@@ -2,28 +2,70 @@ BITS 64                 ; 64-bit mode
 SECTION .text           ; Code section
 GLOBAL memmove          ; export "memmove"
 
-
 memmove:
-        ENTER 0, 0              ; Prologue
-        XOR RCX, RCX            ; Initialize counter
-        JMP .check_null         ; Jump to check for null pointers
+        ENTER 0, 0       ; Prolog
+        MOV RAX, RDI     ; Copy dest to RAX
+        JMP .loop        ; Jump to loop
 
         .loop:
-                CMP RDX, RCX            ; Compare counter with length
-                JE .end                 ; Jump to end if equal
-                MOV R8B, [RSI + RCX]   ; Move byte from source to R8B
-                MOV [RDI + RCX], R8B   ; Move byte from R8B to destination
-                INC RCX                 ; Increment counter
-                JMP .loop               ; Jump to loop
+                CMP RSI, RDI    ; Compare src with dest
+                JG .memcpy      ; If src > dest -> jump to memcpy
+                CALL .memmove_stack   ; Else call memmove
 
-        .check_null:
-                CMP RDI, 0              ; Check if destination pointer is null
-                JE .end                 ; Jump to end if null
-                CMP RSI, 0              ; Check if source pointer is null
-                JE .end                 ; Jump to end if null
-                JMP .loop               ; Jump to compare if not null
+        .memmove_stack:
+                CALL memmove_stack ; call memmove_stack
+                JMP .end        ; jump to end
+
+        .memcpy:
+                CALL memcpy     ; call memcpy
+                JMP .end        ; jump to end
 
         .end:
-                MOV RAX, RDI            ; Return destination pointer
-                LEAVE                   ; Epilogue
-                RET                     ; Return
+                MOV RAX, RDI    ; return dest
+                LEAVE           ; Epilog
+                RET             ; Return
+
+memmove_stack:
+        ENTER 0, 0              ; Prolog
+        MOV RCX, 0              ; Initialize counter
+        JMP .push_rsi           ; Jump to .push_rsi
+
+        .push_rsi:
+                CMP RCX, RDX                    ; Compare counter with len
+                JE .pop_rsi                     ; If equals -> jump to .pop_rsi
+                MOV R8B, BYTE [RSI + RCX]       ; Move byte from src to R8B
+                PUSH R8                         ; Push byte to stack
+                INC RCX                         ; Increment counter
+                JMP .push_rsi                   ; Loop
+
+        .pop_rsi:
+                CMP RCX, 0                      ; Compare counter with 0
+                JE .exit                        ; If equals -> jump to .exit
+                POP R8                          ; Pop byte from stack
+                DEC RCX                         ; Decrement counter
+                MOV BYTE [RDI + RCX], R8B       ; Move byte from R8B to dest
+                JMP .pop_rsi                    ; Loop
+
+        .exit:
+                MOV RAX, RDI                    ; Return dest
+                LEAVE                           ; Epilog
+                RET                             ; Return
+
+memcpy:
+        ENTER 0, 0      ; Prolog
+        MOV RCX, RDX    ; Copy length to RCX
+        MOV RAX, RDI    ; Copy source to RAX
+
+        .loop:
+                CMP RCX, 0      ; If length is 0, we're done
+                JE .done
+                MOV R8B, BYTE [RSI]   ; Copy the byte to a tmp register
+                MOV BYTE [RDI], R8B   ; Copy the byte to the destination
+                INC RDI         ; Move source pointer
+                INC RSI         ; Move destination pointer
+                DEC RCX         ; Decrement length
+                JMP .loop       ; Repeat
+
+        .done:
+                LEAVE           ; Epilog
+                RET             ; Return

--- a/tests/tests_memmove.c
+++ b/tests/tests_memmove.c
@@ -134,13 +134,13 @@ Test(memmove, negative_overlap_2)
 
 Test(memmove, big_string)
 {
-    char src[800000];
-    char dest[800000];
+    char src[2000000];
+    char dest[2000000];
     int tmp;
 
-    memset(src, 'a', 800000);
-    memset(dest, 'b', 800000);
-    my_memmove(dest, src, 800000);
+    memset(src, 'a', 2000000);
+    memset(dest, 'b', 2000000);
+    my_memmove(dest, src, 2000000);
     cr_assert_eq(tmp, 0);
 }
 


### PR DESCRIPTION
I fixed the memmove function to pass a test which consist of a big buffer and an overlap